### PR TITLE
Add touchscreen support

### DIFF
--- a/src/client/game/index.js
+++ b/src/client/game/index.js
@@ -17,8 +17,9 @@ export default class Game {
     this.initPlayers(players);
     if(controlledPlayer){
       this.player = controlledPlayer === 1 ? this.player1 : this.player2;
-      this.mouseMoved = this.mouseMoved.bind(this);
-      window.addEventListener('mousemove', this.mouseMoved);
+      this.pointerMoved = this.pointerMoved.bind(this);
+      window.addEventListener('pointermove', this.pointerMoved);
+      window.addEventListener('pointerdown', this.pointerMoved);
     }
 
     window.addEventListener('keydown', this.fullscreenHandler);
@@ -81,7 +82,7 @@ export default class Game {
     }
   }
 
-  mouseMoved(e){
+  pointerMoved(e){
     if(!this.canvasHeight){
       this.canvasHeight = document.querySelector('canvas').clientHeight;
     }
@@ -113,7 +114,8 @@ export default class Game {
   destroy(){
     this.app.destroy(true, true);
     this.registeredEvents.forEach(type => this.socket.off(type));
-    window.removeEventListener('mousemove', this.mouseMoved);
+    window.removeEventListener('pointermove', this.pointerMoved);
+    window.removeEventListener('pointerdown', this.pointerMoved);
     window.removeEventListener('keydown', this.fullscreenHandler);
   }
 }

--- a/src/client/game/index.js
+++ b/src/client/game/index.js
@@ -20,6 +20,9 @@ export default class Game {
       this.pointerMoved = this.pointerMoved.bind(this);
       window.addEventListener('pointermove', this.pointerMoved);
       window.addEventListener('pointerdown', this.pointerMoved);
+      this.resizeHandler = (e => this.canvasHeight = this.app.view.clientHeight).bind(this);
+      window.addEventListener('resize', this.resizeHandler);
+      this.resizeHandler();
     }
 
     window.addEventListener('keydown', this.fullscreenHandler);
@@ -83,10 +86,7 @@ export default class Game {
   }
 
   pointerMoved(e){
-    if(!this.canvasHeight){
-      this.canvasHeight = document.querySelector('canvas').clientHeight;
-    }
-    this.player.y = e.layerY * 1080 / this.canvasHeight;
+    this.player.y = e.layerY * this.app.renderer.screen.height / this.canvasHeight;
     this.socket.emit('playerMove', {y: this.player.y});
   }
 
@@ -116,6 +116,7 @@ export default class Game {
     this.registeredEvents.forEach(type => this.socket.off(type));
     window.removeEventListener('pointermove', this.pointerMoved);
     window.removeEventListener('pointerdown', this.pointerMoved);
+    window.removeEventListener('resize', this.resizeHandler);
     window.removeEventListener('keydown', this.fullscreenHandler);
   }
 }

--- a/src/client/game/objects/Field.js
+++ b/src/client/game/objects/Field.js
@@ -19,6 +19,9 @@ export default class Field extends BaseField {
     super(players, options);
     this.app = app;
     this.graphics = new PIXI.Graphics();
+    this.graphics.lineStyle(2, 0xFFFFFF);
+    this.graphics.drawRect(2, 2, this.w - 2, this.h - 2);
+    this.graphics.lineStyle(0, 0xFFFFFF);
     for(let i = 0; i * 50 < this.h; i++){
       this.graphics.beginFill(0xFFFFFF);
       this.graphics.drawRect(this.w / 2 - 2.5, 50 * i + 10, 5, 30);

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no">
     <title>Pong 3.0</title>
     <link rel="shortcut icon" href="./assets/favicon.ico">
   </head>

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -63,3 +63,12 @@ const App = () => {
 };
 
 ReactDOM.render(<App/>, document.getElementById('app'));
+
+window.addEventListener("orientationchange", (event) => {
+  const angle = Math.abs(event.target.screen.orientation.angle);
+  if(angle === 90 || angle === 270) {
+    document.body.requestFullscreen();
+  } else {
+    document.exitFullscreen();
+  }
+});

--- a/src/client/style.scss
+++ b/src/client/style.scss
@@ -98,10 +98,9 @@ input:placeholder-shown + button[type="submit"], button.disabled {
 }
 
 .game-container {
-  height: calc(100vh - 2px);
   display: flex;
   width: 133vh;
-  border: 1px solid white;
+  height: 100vh;
 }
 
 .spectators-list {


### PR DESCRIPTION
Canvas was resized only with respect to the height. To fix it I added `object-fit` property. But because of that css border become useless. So I made border as part of field. I think shaking is now more dramatic :D
I don't know PIXI, so I might did strange thing with lineStyle..

PIXI by default sets `touch-action: none` to canvas. I suppose to disable reload and zoom gestures. So I replaced mouse events with pointer events, which is 2 in 1.

If you turn phone in landscape orientation, the game now becomes fullscreen.
But there's a security limitation - user has to make any gesture before fullscreen call. And dynamic listener assigned on game start makes this feature too unreliable. So I've placed listener for it in the root of the app :-/

Also added listener for resize, so player position is correct in case if you resized viewport in the middle of the game.