### PR TITLE
[FIX] set initial height of canvas before canvas element mounted

### DIFF
--- a/src/client/components/GameContainer.jsx
+++ b/src/client/components/GameContainer.jsx
@@ -1,11 +1,17 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 
-const GameContainer = ({game, spectators}) => (
-  <div className="game-container" ref={container => container && container.appendChild(game.element)}>
-    <ul className="spectators-list">
-      {spectators.map(spectator => <li key={spectator}>{spectator}</li>)}
-    </ul>
-  </div>
-);
+const GameContainer = ({game, spectators}) => {
+  useEffect(() => {
+    game.resizeHandler();
+  }, [game]);
+
+  return (
+    <div className="game-container" ref={container => container && container.appendChild(game.element)}>
+      <ul className="spectators-list">
+        {spectators.map(spectator => <li key={spectator}>{spectator}</li>)}
+      </ul>
+    </div>
+  );
+};
 
 export default GameContainer;

--- a/src/client/game/index.js
+++ b/src/client/game/index.js
@@ -20,8 +20,7 @@ export default class Game {
       this.pointerMoved = this.pointerMoved.bind(this);
       window.addEventListener('pointermove', this.pointerMoved);
       window.addEventListener('pointerdown', this.pointerMoved);
-      this.canvasHeight = document.body.clientHeight;
-      this.resizeHandler = (e => this.canvasHeight = this.element.clientHeight).bind(this);
+      this.resizeHandler = this.resizeHandler.bind(this);
       window.addEventListener('resize', this.resizeHandler);
     }
 
@@ -94,6 +93,10 @@ export default class Game {
     this.field.setBalls.bind(this.field)(ballScore.balls);
     this.field.score = ballScore.score;
     this.field.updateScore();
+  }
+
+  resizeHandler(e){
+    this.canvasHeight = this.element.clientHeight;
   }
 
   fullscreenHandler(e){

--- a/src/client/game/index.js
+++ b/src/client/game/index.js
@@ -20,9 +20,9 @@ export default class Game {
       this.pointerMoved = this.pointerMoved.bind(this);
       window.addEventListener('pointermove', this.pointerMoved);
       window.addEventListener('pointerdown', this.pointerMoved);
-      this.resizeHandler = (e => this.canvasHeight = this.app.view.clientHeight).bind(this);
+      this.canvasHeight = document.body.clientHeight;
+      this.resizeHandler = (e => this.canvasHeight = this.element.clientHeight).bind(this);
       window.addEventListener('resize', this.resizeHandler);
-      this.resizeHandler();
     }
 
     window.addEventListener('keydown', this.fullscreenHandler);


### PR DESCRIPTION
Oh no, bug passed manual testing...
You can't control pad without resizing viewport. Because I was using resize handler that takes size of canvas. But apparently PIXI didn't mounted it at that moment. It even doesn't have a parentElement.