### PR TITLE
Move score info in one place and add bonus icons

### DIFF
--- a/src/client/game/index.js
+++ b/src/client/game/index.js
@@ -36,9 +36,7 @@ export default class Game {
     this.on('playerMove', this.movePlayer.bind(this));
     this.on('playerScored', this.playerScored.bind(this));
     this.on('bonusSpawned', this.field.spawnBonus.bind(this.field));
-    this.on('bonusCollected', (bonusesPaddles) => {
-      this.field.setBonuses(bonusesPaddles.bonuses);
-    });
+    this.on('bonusCollected', this.field.setBonuses.bind(this.field);
     this.on('collision', ({pos: {x, y}, vel: {x: vx, y: vy}}) => {
       this.particleGroups.push(new CollisionParticles({
         x, y,

--- a/src/client/game/index.js
+++ b/src/client/game/index.js
@@ -36,7 +36,7 @@ export default class Game {
     this.on('playerMove', this.movePlayer.bind(this));
     this.on('playerScored', this.playerScored.bind(this));
     this.on('bonusSpawned', this.field.spawnBonus.bind(this.field));
-    this.on('bonusCollected', this.field.setBonuses.bind(this.field);
+    this.on('bonusCollected', this.field.setBonuses.bind(this.field));
     this.on('collision', ({pos: {x, y}, vel: {x: vx, y: vy}}) => {
       this.particleGroups.push(new CollisionParticles({
         x, y,

--- a/src/client/game/index.js
+++ b/src/client/game/index.js
@@ -37,6 +37,7 @@ export default class Game {
     this.on('playerScored', this.playerScored.bind(this));
     this.on('bonusSpawned', this.field.spawnBonus.bind(this.field));
     this.on('bonusCollected', this.field.setBonuses.bind(this.field));
+    this.on('bonusActivated', this.field.updateBonusIcons.bind(this.field));
     this.on('collision', ({pos: {x, y}, vel: {x: vx, y: vy}}) => {
       this.particleGroups.push(new CollisionParticles({
         x, y,

--- a/src/client/game/objects/Field.js
+++ b/src/client/game/objects/Field.js
@@ -101,9 +101,9 @@ export default class Field extends BaseField {
     this.graphics.removeChild(bonus.graphics);
   }
 
-  setBonuses(bonuses){
+  setBonuses(bonusesPaddles){
     this.bonuses.forEach(b => this.graphics.removeChild(b.graphics));
-    this.bonuses = bonuses.map(b => new DoubleBall(b.x, b.y));
+    this.bonuses = bonusesPaddles.bonuses.map(b => new DoubleBall(b.x, b.y));
     this.bonuses.forEach(b => this.graphics.addChild(b.graphics));
   }
 

--- a/src/client/game/objects/Field.js
+++ b/src/client/game/objects/Field.js
@@ -32,11 +32,19 @@ export default class Field extends BaseField {
       fill: 0xffffff,
       strokeThickness: 4,
     };
-    this.scoreText = new PIXI.Text('', textSettings);
+    this.playerScore1 = new PIXI.Text('', textSettings);
+    this.playerScore1.anchor.set(1, 0); // top right
+    Object.assign(this.playerScore1, {x: this.w / 2 - 30, y: 5});
+    this.playerScore2 = new PIXI.Text('', textSettings);
+    this.playerScore2.anchor.set(0, 0); // top left
+    Object.assign(this.playerScore2, {x: this.w / 2 + 30, y: 5});
+
     const playerName1 = new PIXI.Text(players[0].name, textSettings);
-    Object.assign(playerName1, {x: 10, y: 5});
+    playerName1.anchor.set(1, 0); // top right
+    Object.assign(playerName1, {x: this.w / 2 - 150, y: 5});
     const playerName2 = new PIXI.Text(players[1].name, textSettings);
-    Object.assign(playerName2, {x: this.w - playerName2.width - 10, y: 5});
+    playerName2.anchor.set(0, 0); // top left
+    Object.assign(playerName2, {x: this.w / 2 + 150, y: 5});
 
     this.updateScore();
     app.ticker.add(this.update.bind(this));
@@ -46,7 +54,8 @@ export default class Field extends BaseField {
       players[0].graphics,
       players[1].graphics,
       this.balls[0].graphics,
-      this.scoreText,
+      this.playerScore1,
+      this.playerScore2,
       playerName1,
       playerName2,
     );
@@ -54,9 +63,8 @@ export default class Field extends BaseField {
   }
 
   updateScore(){
-    this.scoreText.text = `${this.score.player1} - ${this.score.player2}`;
-    this.scoreText.x = this.w - this.scoreText.width - 10;
-    this.scoreText.y = this.h - this.scoreText.height - 5;
+    this.playerScore1.text = this.score.player1;
+    this.playerScore2.text = this.score.player2;
   }
 
   setBalls(balls){

--- a/src/client/game/objects/Field.js
+++ b/src/client/game/objects/Field.js
@@ -105,6 +105,25 @@ export default class Field extends BaseField {
     this.bonuses.forEach(b => this.graphics.removeChild(b.graphics));
     this.bonuses = bonusesPaddles.bonuses.map(b => new DoubleBall(b.x, b.y));
     this.bonuses.forEach(b => this.graphics.addChild(b.graphics));
+    this.updateBonusIcons(bonusesPaddles.players);
+  }
+
+  updateBonusIcons(players){
+    const bonusIconRadius = 10;
+    const iconMargin = 5;
+    const computeIconOffset = i => 150 + i * (bonusIconRadius * 2 + iconMargin) + bonusIconRadius * 1.3;
+
+    this.players.forEach((player, playerNumber) => {
+      player.bonusIcons.forEach(b => this.graphics.removeChild(b.graphics));
+      const direction = playerNumber % 2 ? 1 : -1;
+      player.bonusIcons = players[playerNumber].bonuses
+        .map((_, i) => {
+          const x = this.w / 2 + direction * computeIconOffset(i);
+          const y = 50 + bonusIconRadius;
+          return new DoubleBall(x, y, bonusIconRadius);
+        });
+      player.bonusIcons.forEach(b => this.graphics.addChild(b.graphics));
+    });
   }
 
   shake({x, y}){

--- a/src/client/game/objects/Paddle.js
+++ b/src/client/game/objects/Paddle.js
@@ -9,6 +9,7 @@ export default class Paddle extends BasePaddle {
     this.graphics.drawRect(-this.w / 2, -this.h / 2, this.w, this.h);
     this.graphics.endFill();
     Object.assign(this, options);
+    this.bonusIcons = [];
   }
 
   set x(value){

--- a/src/client/game/objects/bonuses/DoubleBall.js
+++ b/src/client/game/objects/bonuses/DoubleBall.js
@@ -2,8 +2,8 @@ import * as PIXI from 'pixi.js';
 import {BaseDoubleBall} from '/../common/game/objects/bonuses';
 
 export default class DoubleBall extends BaseDoubleBall {
-  constructor(x, y){
-    super(x, y);
+  constructor(x, y, radius){
+    super(x, y, radius);
     const g = new PIXI.Graphics();
     const unit = this.radius / 10;
     g.beginFill(0);

--- a/src/common/game/objects/BaseField.js
+++ b/src/common/game/objects/BaseField.js
@@ -3,7 +3,7 @@ const Paddle = require ('./BasePaddle');
 const {BaseDoubleBall} = require('./bonuses');
 
 module.exports = class BaseField {
-  constructor(options){
+  constructor(players, options){
     this.listeners = [];
     const defaults = {
       h: 1080,
@@ -12,7 +12,7 @@ module.exports = class BaseField {
     Object.assign(defaults, options);
     Object.assign(this, defaults);
     this.center = {x: this.w / 2, y: this.h / 2};
-    this.players = [
+    this.players = players || [
       new Paddle({
         x: 30,
         y: this.h / 2,

--- a/src/common/game/objects/BaseField.js
+++ b/src/common/game/objects/BaseField.js
@@ -136,6 +136,6 @@ module.exports = class BaseField {
   }
 
   addBonus(){
-    this.bonuses.push(new BaseDoubleBall(this.w / 3 + Math.random() * this.w / 3, Math.random() * this.h));
+    this.bonuses.push(new BaseDoubleBall(this.w / 3 + Math.random() * this.w / 3, this.h / 8 + 7 * Math.random() * this.h / 8));
   }
 };

--- a/src/common/game/objects/BasePaddle.js
+++ b/src/common/game/objects/BasePaddle.js
@@ -33,6 +33,7 @@ module.exports = class BasePaddle {
     const bonus = this.bonuses.shift();
     if(bonus){
       bonus.activate(ball, field);
+      field.emit('bonusActivated');
     }
   }
 };

--- a/src/common/game/objects/BonusTemplate.js
+++ b/src/common/game/objects/BonusTemplate.js
@@ -1,6 +1,6 @@
 module.exports = class BonusTemplate {
-  constructor(){
-    this.radius = 50;
+  constructor(radius = 50){
+    this.radius = radius;
     this.player = null;
   }
 

--- a/src/common/game/objects/bonuses/BaseDoubleBall.js
+++ b/src/common/game/objects/bonuses/BaseDoubleBall.js
@@ -2,8 +2,8 @@ const BonusTemplate = require('../BonusTemplate');
 const Ball = require('../BaseBall');
 
 module.exports = class BaseDoubleBall extends BonusTemplate {
-  constructor(x, y){
-    super();
+  constructor(x, y, radius){
+    super(radius);
     this.x = x;
     this.y = y;
     this.type = 'DoubleBall';

--- a/src/server/Room.js
+++ b/src/server/Room.js
@@ -75,6 +75,9 @@ module.exports = class Room {
         players: this.field.players,
       });
     });
+    this.field.on('bonusActivated', () => {
+      this.broadcast('bonusActivated', this.field.players);
+    });
     this.tick(this.field);
   }
 


### PR DESCRIPTION
Player names and score info now located at top in the middle of the field. Because of that I limited area where bonuses can spawn so they don't cover this info.
Fixed `BaseField` class - it was not using players that was passed to it on client side.